### PR TITLE
feat: implement session deletion

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -43,12 +43,24 @@ async function setSessionCookie(sessionToken, response) {
   response.setHeader("Set-Cookie", setCookie);
 }
 
+async function clearSessionCookie(response) {
+  const setCookie = cookie.serialize("session_id", "invalid", {
+    path: "/",
+    maxAge: -1,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  });
+
+  response.setHeader("Set-Cookie", setCookie);
+}
+
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
     onError: onErrorHandler,
   },
   setSessionCookie,
+  clearSessionCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -86,10 +86,35 @@ async function renew(sessionId) {
   }
 }
 
+async function expireById(sessionId) {
+  const expiresSessionObject = await runUpdateQuery(sessionId);
+  return expiresSessionObject;
+
+  async function runUpdateQuery(sessionId) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          sessions
+        SET
+          expires_at = expires_at - interval '1 year',
+          updated_at = timezone('utc', now())
+        WHERE
+          id = $1
+        RETURNING
+          *
+      ;`,
+      values: [sessionId],
+    });
+
+    return results.rows[0];
+  }
+}
+
 const session = {
   findOneValidByToken,
   create,
   renew,
+  expireById,
   EXPIRATION_IN_MILISECONDS,
 };
 

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -6,6 +6,7 @@ import session from "models/session.js";
 const router = createRouter();
 
 router.post(postHandler);
+router.delete(deleteHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -26,4 +27,14 @@ async function postHandler(request, response) {
     "no-store, no-cache, max-age=0, must-revalidate",
   );
   return response.status(201).json(newSession);
+}
+
+async function deleteHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const expiredSession = await session.expireById(sessionObject.id);
+  controller.clearSessionCookie(response);
+
+  return response.status(200).json(expiredSession);
 }

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,0 +1,141 @@
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+
+import orchestrator from "tests/orchestrator.js";
+import session from "models/session.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("DELETE /api/v1/sessions", () => {
+  describe("Default user", () => {
+    test("With nonexistent session", async () => {
+      const nonexistentToken =
+        "4b4cd2bbced904b1115e52ab174d624fc7985e22ff035800699377e206a90fa39dd43e4ee36280fd84b152fff657ea9a";
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser();
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithValidSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/sessions", {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: sessionObject.id,
+        token: sessionObject.token,
+        user_id: sessionObject.user_id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(
+        responseBody.expires_at < sessionObject.expires_at.toISOString(),
+      ).toBe(true);
+      expect(
+        responseBody.updated_at > sessionObject.updated_at.toISOString(),
+      ).toBe(true);
+
+      // Set-Cookies assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
+
+      // Double check assertions
+      const doubleCheckResponse = await fetch(
+        "http://localhost:3000/api/v1/user",
+        {
+          headers: {
+            Cookie: `session_id=${sessionObject.token}`,
+          },
+        },
+      );
+
+      expect(doubleCheckResponse.status).toBe(401);
+
+      const doubleCheckResponseBody = await doubleCheckResponse.json();
+
+      expect(doubleCheckResponseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces support for logging out users by implementing a `DELETE` endpoint for sessions. It includes backend logic to expire sessions, clear the session cookie, and comprehensive integration tests to ensure correct behavior for valid, expired, and nonexistent sessions.

**Session expiration and logout functionality:**

* Added a new `expireById` method to the `session` model, which marks a session as expired in the database by setting its expiration date to the past.
* Implemented a `clearSessionCookie` function in the controller to invalidate the session cookie on logout.
* Added a `DELETE /api/v1/sessions` endpoint handler that finds the session by token, expires it, and clears the cookie.

**Testing:**

* Added integration tests for the new DELETE endpoint, covering cases for nonexistent, expired, and valid sessions, including assertions for proper cookie invalidation and session expiration.