### PR TITLE
Add MainTemplate to status page

### DIFF
--- a/pages/status/index.js
+++ b/pages/status/index.js
@@ -1,5 +1,6 @@
 import useSWR from "swr";
-import { Stack, Heading, Text, PageLayout } from "@primer/react";
+import { Stack, Heading, Text } from "@primer/react";
+import { MainTemplate } from "templates/MainTemplate/index.jsx";
 
 async function fetchAPI(key) {
   const response = await fetch(key);
@@ -9,17 +10,13 @@ async function fetchAPI(key) {
 
 export default function StatusPage() {
   return (
-    <>
-      <PageLayout>
-        <PageLayout.Content>
-          <Stack>
-            <Heading as="h1">Status</Heading>
-            <UpdatedAt />
-            <DatabaseStatus />
-          </Stack>
-        </PageLayout.Content>
-      </PageLayout>
-    </>
+    <MainTemplate>
+      <Stack>
+        <Heading as="h1">Status</Heading>
+        <UpdatedAt />
+        <DatabaseStatus />
+      </Stack>
+    </MainTemplate>
   );
 }
 

--- a/templates/MainTemplate/index.jsx
+++ b/templates/MainTemplate/index.jsx
@@ -1,0 +1,17 @@
+import { PageLayout } from "@primer/react";
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+
+export function MainTemplate({ children }) {
+  return (
+    <>
+      <Header />
+      <PageLayout containerWidth="large" padding="none">
+        <PageLayout.Content padding="normal">{children}</PageLayout.Content>
+        <PageLayout.Footer divider="line">
+          <Footer />
+        </PageLayout.Footer>
+      </PageLayout>
+    </>
+  );
+}


### PR DESCRIPTION
This pull request refactors the layout of the `StatusPage` to use a new shared layout component, improving consistency and code reuse across the app. The main change is the introduction of the `MainTemplate` component, which wraps pages with a common header, footer, and layout structure.

**Layout refactor:**
* Created a new `MainTemplate` component in `templates/MainTemplate/index.jsx` that standardizes the page layout with a header, footer, and content area using `PageLayout` from Primer React.
* Updated `pages/status/index.js` to use the new `MainTemplate` instead of directly using `PageLayout`, and removed the now-unnecessary import of `PageLayout`. [[1]](diffhunk://#diff-38358ee16d8173463f03c9a623e710c50cbf57fe7abd7ad2abab885755dcae94L2-R3) [[2]](diffhunk://#diff-38358ee16d8173463f03c9a623e710c50cbf57fe7abd7ad2abab885755dcae94L12-R19)

This change makes it easier to maintain a consistent look and feel across pages and centralizes layout logic.